### PR TITLE
Add logic to append a suffix if the tab name is repeated.

### DIFF
--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -1007,11 +1007,29 @@ dossierProgramsModule.controller("dossiersProgramExport", [
         @description Makes a sheet from Stage Section / Data Elements data
         @scope dossiersProgramExport
         */
-        function makeStageSectionSheetName(stageName, sectionName) {
+        function makeStageSectionSheetName(stageName, sectionName, sheetsNamesCount) {
             const stageNameSlice = stageName.replace(/[\\/*?:[\]]/g, "").slice(0, 20);
             const stageNameSliceLen = stageNameSlice.length !== 20 ? 20 - stageNameSlice.length + 10 : 10;
             const sectionNameSlice = sectionName.replace(/[\\/*?:[\]]/g, "").slice(0, stageNameSliceLen);
-            return `${stageNameSlice}-${sectionNameSlice}`;
+            let name = `${stageNameSlice}-${sectionNameSlice}`;
+
+            if (sheetsNamesCount.hasOwnProperty(name)) {
+                const count = sheetsNamesCount[name];
+                const countStrLen = count.toString().length;
+                const nameLen = name.length;
+
+                sheetsNamesCount[name] += 1;
+
+                if (nameLen < 31 - countStrLen) {
+                    name = name + `-${count}`;
+                } else {
+                    const sliceLen = 30 - nameLen - countStrLen;
+                    name = name.slice(0, sliceLen) + `-${count}`;
+                }
+            } else {
+                sheetsNamesCount[name] = 0;
+            }
+            return name;
         }
 
         /*
@@ -1069,13 +1087,15 @@ dossierProgramsModule.controller("dossiersProgramExport", [
         @scope dossiersProgramExport
         */
         function makeStagesSheets(workbook, stages) {
+            let sheetsNamesCount = {};
             stages.forEach(stage => {
                 stage.programStageSections.forEach(section => {
-                    makeStageSectionSheet(
-                        workbook,
-                        section.dataElements,
-                        makeStageSectionSheetName(stage.displayName, section.displayName)
+                    const sheetsName = makeStageSectionSheetName(
+                        stage.displayName,
+                        section.displayName,
+                        sheetsNamesCount
                     );
+                    makeStageSectionSheet(workbook, section.dataElements, sheetsName);
                 });
             });
         }

--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -1014,11 +1014,11 @@ dossierProgramsModule.controller("dossiersProgramExport", [
             let name = `${stageNameSlice}-${sectionNameSlice}`;
 
             if (sheetsNamesCount.hasOwnProperty(name)) {
+                sheetsNamesCount[name] += 1;
+
                 const count = sheetsNamesCount[name];
                 const countStrLen = count.toString().length;
                 const nameLen = name.length;
-
-                sheetsNamesCount[name] += 1;
 
                 if (nameLen < 31 - countStrLen) {
                     name = name + `-${count}`;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hmis-dictionary",
     "description": "DHIS2 HMIS Dictionary app",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "license": "GPL-3.0",
     "author": "MSF OCBA, EyeSeeTea team",
     "repository": {


### PR DESCRIPTION
## Fix: Add logic to append a suffix if the tab name is repeated.
### References

- Issue: [Duplicate excel tab name error](https://app.clickup.com/t/865bqx5kd)

### Description

- As we are truncating the Program Stage Section name because there is a limitation in the name of the excel tab names (31 chars max), two long names can end up generating repeating names.
- This fix will add a suffix (-[number]) to avoid this kind of errors, removing the necessary number of characters from the name to make it fit.
- The first instance of the repeating name don't get the suffix as it may make more difficult to identify the Program Stage Section name.