### PR TITLE
Fix loading status not displaying and incorrect calc. mode

### DIFF
--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -721,6 +721,7 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
                 startLoadingState(false);
                 dossiersProgramLoadingService.loading.programIndicators = false;
                 $rootScope.recursiveAssignFilterDone = false;
+                $rootScope.programIndicatorsEmpty = false;
 
                 dossiersProgramIndicatorsFactory.get(
                     {
@@ -753,6 +754,8 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
                                     $rootScope.programIndicators = $scope.programIndicators;
                                     $rootScope.programStages = $scope.programStages;
                                     dossiersProgramDataService.data.programIndicators = $scope.programIndicators;
+                                } else {
+                                    $rootScope.programIndicatorsEmpty = true;
                                 }
                                 dossiersProgramLoadingService.loading.programIndicators = true;
                                 if (dossiersProgramLoadingService.done()) endLoadingState(true);
@@ -904,7 +907,13 @@ dossierProgramsModule.controller("dossierProgramGlobalIndicatorController", [
          *  @scope dossierProgramGlobalIndicatorController
          */
         $scope.$watchGroup(
-            ["selectedProgram", "programIndicators", "programStages", "recursiveAssignFilterDone"],
+            [
+                "selectedProgram",
+                "programIndicators",
+                "programStages",
+                "recursiveAssignFilterDone",
+                "programIndicatorsEmpty",
+            ],
             function () {
                 ping();
                 $scope.programIndicators = $rootScope.programIndicators;
@@ -938,8 +947,7 @@ dossierProgramsModule.controller("dossierProgramGlobalIndicatorController", [
                         dossiersProgramLoadingService.loading.indicators = true;
                         if (dossiersProgramLoadingService.done()) endLoadingState(true);
                     });
-                    // TODO: temp fix, need a way of signaling that dossiersProgramIndicatorController ended to dossierProgramGlobalIndicatorController
-                } else if ($scope.selectedProgram.displayName === "BOAT Medical Linelist") {
+                } else if ($rootScope.programIndicatorsEmpty) {
                     dossiersProgramLoadingService.loading.indicators = true;
                     if (dossiersProgramLoadingService.done()) endLoadingState(true);
                 }

--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -10,7 +10,16 @@ dossierProgramsModule.controller("dossierProgramsMainController", [
     "$sce",
     "dossiersProgramsFactory",
     "dossiersProgramsLinkTestFactory",
-    function ($scope, $translate, $anchorScroll, $sce, dossiersProgramsFactory, dossiersProgramsLinkTestFactory) {
+    "dossiersProgramLoadingService",
+    function (
+        $scope,
+        $translate,
+        $anchorScroll,
+        $sce,
+        dossiersProgramsFactory,
+        dossiersProgramsLinkTestFactory,
+        dossiersProgramLoadingService
+    ) {
         $("#dossiersPrograms").tab("show");
 
         /*
@@ -63,6 +72,7 @@ dossierProgramsModule.controller("dossierProgramsMainController", [
         //Clear the TOC
         $scope.$watch("selectedProgram", function () {
             ping();
+            dossiersProgramLoadingService.resetState();
             $scope.toc = {
                 entries: [],
             };

--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -286,12 +286,16 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
                     }
                 });
 
-                return {
-                    name: pr.name,
-                    stageId: pr.programStage?.id,
-                    allwaysHidden: hideSectionAction ? pr.condition === "true" : undefined,
-                    ids: idArray,
-                };
+                if (idArray.length > 0) {
+                    return {
+                        name: pr.name,
+                        stageId: pr.programStage?.id,
+                        allwaysHidden: hideSectionAction ? pr.condition === "true" : undefined,
+                        ids: idArray,
+                    };
+                } else {
+                    return [];
+                }
             });
         }
 

--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -195,6 +195,26 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
         }
 
         /*
+         *  @name isRuleInScope
+         *  @description Determine if the rule applies to the stage/section
+         *  @scope dossiersProgramSectionController
+         */
+        function isRuleInScope(rule, stageId) {
+            let stageScope = false;
+            if (rule.stageId) {
+                stageScope = rule.stageId === stageId;
+            } else {
+                stageScope = true;
+            }
+
+            if (typeof rule.allwaysHidden !== "undefined") {
+                return stageScope && rule.allwaysHidden;
+            } else {
+                return stageScope;
+            }
+        }
+
+        /*
          *  @name makeSectionsCalcMode
          *  @description Determine the "Calculation mode" of the stage sections data elements
          *  @scope dossiersProgramSectionController
@@ -203,10 +223,10 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
             stage.programStageSections.forEach(pss => {
                 pss.dataElements.forEach(pssDE => {
                     assignedDEArray.forEach(adeArray => {
-                        if (adeArray.ids?.includes(pssDE.id) && adeArray.stageId === stage.id) {
+                        if (adeArray.ids?.includes(pssDE.id) && isRuleInScope(adeArray, stage.id)) {
                             if (!pssDE.calcMode || pssDE.calcMode.type === "default") {
                                 pssDE.calcMode = { type: "programRule", names: [adeArray.name] };
-                            } else {
+                            } else if (pssDE.calcMode.type === "programRule") {
                                 pssDE.calcMode.names.push(adeArray.name);
                             }
                         } else if (!pssDE.calcMode) {
@@ -216,7 +236,7 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
 
                     hiddenSectionsArray.forEach(hsArray => {
                         if (hsArray.ids.includes(pss.id)) {
-                            if (pssDE.calcMode.type !== "programRule" && hsArray.allwaysHidden) {
+                            if (pssDE.calcMode.type !== "programRule" && isRuleInScope(hsArray, stage.id)) {
                                 pssDE.calcMode = { type: "other" };
                             }
                         }
@@ -231,18 +251,16 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
          *  @scope dossiersProgramSectionController
          */
         function makeStageCalcMode(stage, assignedDEArray) {
-            stage.programStageDataElements.forEach(psde => {
+            stage.programStageDataElements.forEach(psDE => {
                 assignedDEArray.forEach(adeArray => {
-                    if (adeArray.ids.includes(psde.dataElement.id) && adeArray.stageId === stage.id) {
-                        if (!psde.dataElement.calcMode) {
-                            if (!psde.dataElement.calcMode || psde.dataElement.calcMode.type === "default") {
-                                psde.dataElement.calcMode = { type: "programRule", names: [adeArray.name] };
-                            } else {
-                                psde.dataElement.calcMode.names.push(adeArray.name);
-                            }
+                    if (adeArray.ids.includes(psDE.dataElement.id) && isRuleInScope(adeArray, stage.id)) {
+                        if (!psDE.dataElement.calcMode || psDE.dataElement.calcMode.type === "default") {
+                            psDE.dataElement.calcMode = { type: "programRule", names: [adeArray.name] };
+                        } else if (psDE.dataElement.calcMode.type === "programRule") {
+                            psDE.dataElement.calcMode.names.push(adeArray.name);
                         }
-                    } else if (!psde.dataElement.calcMode) {
-                        psde.dataElement.calcMode = { type: "default" };
+                    } else if (!psDE.dataElement.calcMode) {
+                        psDE.dataElement.calcMode = { type: "default" };
                     }
                 });
             });

--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -78,6 +78,7 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
     "dossiersProgramStageCalcModeFactory",
     "Ping",
     "dossiersProgramDataService",
+    "dossiersProgramLoadingService",
     function (
         $scope,
         $q,
@@ -85,7 +86,8 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
         dossiersProgramStageSectionsFactory,
         dossiersProgramStageCalcModeFactory,
         Ping,
-        dossiersProgramDataService
+        dossiersProgramDataService,
+        dossiersProgramLoadingService
     ) {
         /*
          *  @name makeDEVisibility
@@ -246,6 +248,7 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
             ping();
             if ($scope.selectedProgram) {
                 startLoadingState(false);
+                dossiersProgramLoadingService.loading.programs = false;
                 //Query sections and data elements
                 var stageSectionPromises = $scope.selectedProgram.programStages.map(function (stage) {
                     return dossiersProgramStageSectionsFactory.get({ programStageId: stage.id }).$promise;
@@ -320,7 +323,8 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
                             }
                         });
                         dossiersProgramDataService.data.stages = $scope.stages;
-                        endLoadingState(true);
+                        dossiersProgramLoadingService.loading.programs = true;
+                        if (dossiersProgramLoadingService.done()) endLoadingState(true);
                     });
                 });
             }
@@ -532,6 +536,7 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
     "dossiersProgramIndicatorStagesFactory",
     "dossiersProgramIndicatorsFactory",
     "dossiersProgramDataService",
+    "dossiersProgramLoadingService",
     function (
         $scope,
         $rootScope,
@@ -539,7 +544,8 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
         dossiersProgramIndicatorFilterFactory,
         dossiersProgramIndicatorStagesFactory,
         dossiersProgramIndicatorsFactory,
-        dossiersProgramDataService
+        dossiersProgramDataService,
+        dossiersProgramLoadingService
     ) {
         $scope.programIndicators4TOC = {
             displayName: "Program indicators",
@@ -713,6 +719,7 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
             ping();
             if ($scope.selectedProgram) {
                 startLoadingState(false);
+                dossiersProgramLoadingService.loading.programIndicators = false;
                 $rootScope.recursiveAssignFilterDone = false;
 
                 dossiersProgramIndicatorsFactory.get(
@@ -747,7 +754,8 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
                                     $rootScope.programStages = $scope.programStages;
                                     dossiersProgramDataService.data.programIndicators = $scope.programIndicators;
                                 }
-                                endLoadingState(true);
+                                dossiersProgramLoadingService.loading.programIndicators = true;
+                                if (dossiersProgramLoadingService.done()) endLoadingState(true);
                             }
                         );
                     }
@@ -765,6 +773,7 @@ dossierProgramsModule.controller("dossierProgramGlobalIndicatorController", [
     "dossiersProgramGlobalIndicatorExpressionFactory",
     "Ping",
     "dossiersProgramDataService",
+    "dossiersProgramLoadingService",
     function (
         $scope,
         $rootScope,
@@ -772,7 +781,8 @@ dossierProgramsModule.controller("dossierProgramGlobalIndicatorController", [
         dossiersProgramGlobalIndicatorsFactory,
         dossiersProgramGlobalIndicatorExpressionFactory,
         Ping,
-        dossiersProgramDataService
+        dossiersProgramDataService,
+        dossiersProgramLoadingService
     ) {
         $scope.indicators4TOC = {
             displayName: "Indicators",
@@ -905,6 +915,7 @@ dossierProgramsModule.controller("dossierProgramGlobalIndicatorController", [
                     $rootScope.recursiveAssignFilterDone
                 ) {
                     startLoadingState(false);
+                    dossiersProgramLoadingService.loading.indicators = false;
                     $scope.indicators = [];
 
                     //Query indicator information
@@ -924,8 +935,13 @@ dossierProgramsModule.controller("dossierProgramGlobalIndicatorController", [
                             recursiveAssignDenominator(0);
                             dossiersProgramDataService.data.indicators = $scope.indicators;
                         }
-                        endLoadingState(true);
+                        dossiersProgramLoadingService.loading.indicators = true;
+                        if (dossiersProgramLoadingService.done()) endLoadingState(true);
                     });
+                    // TODO: temp fix, need a way of signaling that dossiersProgramIndicatorController ended to dossierProgramGlobalIndicatorController
+                } else if ($scope.selectedProgram.displayName === "BOAT Medical Linelist") {
+                    dossiersProgramLoadingService.loading.indicators = true;
+                    if (dossiersProgramLoadingService.done()) endLoadingState(true);
                 }
             }
         );
@@ -938,12 +954,14 @@ dossierProgramsModule.controller("dossiersProgramTEAController", [
     "dossiersProgramTEAsFactory",
     "dossiersProgramTEAsRulesFactory",
     "dossiersProgramDataService",
+    "dossiersProgramLoadingService",
     function (
         $scope,
         $translate,
         dossiersProgramTEAsFactory,
         dossiersProgramTEAsRulesFactory,
-        dossiersProgramDataService
+        dossiersProgramDataService,
+        dossiersProgramLoadingService
     ) {
         $scope.trackedEntityAttributes4TOC = {
             displayName: "Tracked Entity Attributes",
@@ -981,6 +999,7 @@ dossierProgramsModule.controller("dossiersProgramTEAController", [
             ping();
             if ($scope.selectedProgram) {
                 startLoadingState(false);
+                dossiersProgramLoadingService.loading.trackedEntityAttributes = false;
 
                 dossiersProgramTEAsFactory.get(
                     {
@@ -1015,8 +1034,8 @@ dossierProgramsModule.controller("dossiersProgramTEAController", [
                                     dossiersProgramDataService.data.trackedEntityAttributes =
                                         $scope.trackedEntityAttributes;
                                 }
-
-                                endLoadingState(true);
+                                dossiersProgramLoadingService.loading.trackedEntityAttributes = true;
+                                if (dossiersProgramLoadingService.done()) endLoadingState(true);
                             }
                         );
                     }
@@ -1033,13 +1052,15 @@ dossierProgramsModule.controller("dossiersProgramRuleController", [
     "dossiersProgramRulesFactory",
     "dossiersProgramRulesActionsTemplateName",
     "dossiersProgramDataService",
+    "dossiersProgramLoadingService",
     function (
         $scope,
         $rootScope,
         $translate,
         dossiersProgramRulesFactory,
         dossiersProgramRulesActionsTemplateName,
-        dossiersProgramDataService
+        dossiersProgramDataService,
+        dossiersProgramLoadingService
     ) {
         $scope.rules4TOC = {
             displayName: "Program Rules",
@@ -1080,6 +1101,7 @@ dossierProgramsModule.controller("dossiersProgramRuleController", [
             ping();
             if ($scope.selectedProgram) {
                 startLoadingState(false);
+                dossiersProgramLoadingService.loading.rules = false;
                 $rootScope.programRulesDone = false;
 
                 dossiersProgramRulesFactory.get(
@@ -1096,7 +1118,9 @@ dossierProgramsModule.controller("dossiersProgramRuleController", [
                         }
 
                         $rootScope.programRulesDone = true;
-                        endLoadingState(true);
+
+                        dossiersProgramLoadingService.loading.rules = true;
+                        if (dossiersProgramLoadingService.done()) endLoadingState(true);
                     }
                 );
             }
@@ -1110,7 +1134,15 @@ dossierProgramsModule.controller("dossiersProgramRuleVariablesController", [
     "$translate",
     "dossiersProgramRuleVariablesFactory",
     "dossiersProgramDataService",
-    function ($scope, $rootScope, $translate, dossiersProgramRuleVariablesFactory, dossiersProgramDataService) {
+    "dossiersProgramLoadingService",
+    function (
+        $scope,
+        $rootScope,
+        $translate,
+        dossiersProgramRuleVariablesFactory,
+        dossiersProgramDataService,
+        dossiersProgramLoadingService
+    ) {
         $scope.ruleVariables4TOC = {
             displayName: "Program Rule Variables",
             id: "RuleVariablesContainer",
@@ -1127,6 +1159,7 @@ dossierProgramsModule.controller("dossiersProgramRuleVariablesController", [
             ping();
             if ($scope.selectedProgram && $rootScope.programRulesDone) {
                 startLoadingState(false);
+                dossiersProgramLoadingService.loading.ruleVariables = false;
 
                 dossiersProgramRuleVariablesFactory.get(
                     {
@@ -1152,7 +1185,8 @@ dossierProgramsModule.controller("dossiersProgramRuleVariablesController", [
                             dossiersProgramDataService.data.ruleVariables = $scope.ruleVariables;
                         }
 
-                        endLoadingState(true);
+                        dossiersProgramLoadingService.loading.ruleVariables = true;
+                        if (dossiersProgramLoadingService.done()) endLoadingState(true);
                     }
                 );
             }
@@ -1166,12 +1200,14 @@ dossierProgramsModule.controller("dossiersProgramResourcesController", [
     "dossiersProgramDataService",
     "dossiersProgramResourcesAttributeFactory",
     "dossiersProgramResourcesElementsFactory",
+    "dossiersProgramLoadingService",
     function (
         $scope,
         $translate,
         dossiersProgramDataService,
         dossiersProgramResourcesAttributeFactory,
-        dossiersProgramResourcesElementsFactory
+        dossiersProgramResourcesElementsFactory,
+        dossiersProgramLoadingService
     ) {
         $scope.resources4TOC = {
             displayName: "Program Resources",
@@ -1240,6 +1276,7 @@ dossierProgramsModule.controller("dossiersProgramResourcesController", [
             ping();
             if ($scope.selectedProgram) {
                 startLoadingState(false);
+                dossiersProgramLoadingService.loading.resources = false;
 
                 dossiersProgramResourcesAttributeFactory.get({ programId: $scope.selectedProgram.id }, function (data) {
                     const resourcesIDs = data.attributeValues
@@ -1277,7 +1314,8 @@ dossierProgramsModule.controller("dossiersProgramResourcesController", [
                             dossiersProgramDataService.data.resources = $scope.resources;
                         }
 
-                        endLoadingState(true);
+                        dossiersProgramLoadingService.loading.resources = true;
+                        if (dossiersProgramLoadingService.done()) endLoadingState(true);
                     });
                 });
             }

--- a/app/dossierPrograms/dossierPrograms.services.js
+++ b/app/dossierPrograms/dossierPrograms.services.js
@@ -507,3 +507,35 @@ dossierProgramsModule.service("dossiersProgramDataService", function () {
         ruleVariables: undefined,
     };
 });
+
+dossierProgramsModule.service("dossiersProgramLoadingService", function () {
+    this.loading = {
+        programs: undefined,
+        programIndicators: undefined,
+        indicators: undefined,
+        trackedEntityAttributes: undefined,
+        rules: undefined,
+        ruleVariables: undefined,
+        resources: undefined,
+    };
+
+    this.resetState = function () {
+        this.loading = {
+            programs: undefined,
+            programIndicators: undefined,
+            indicators: undefined,
+            trackedEntityAttributes: undefined,
+            rules: undefined,
+            ruleVariables: undefined,
+            resources: undefined,
+        };
+    };
+
+    this.done = function () {
+        if (Object.values(this.loading).every(Boolean)) {
+            this.resetState();
+            return true;
+        }
+        return false;
+    };
+});

--- a/app/search/search.controllers.js
+++ b/app/search/search.controllers.js
@@ -664,6 +664,22 @@ searchModule.controller("searchController", [
             return $translate.instant(tag);
         }
 
+        /* 
+        @name stripHTML
+        @description strip the HTML tags to get the same output as the search dossier table
+        @scope searchController
+        */
+        function stripHTML(value) {
+            const tooltiptextRegex = /<span class=['"]tooltiptext['"]>.*?<\/span>/gi;
+            const htmlRegex = /<[^<>]+>/gi;
+
+            return value
+                .replace(/(\r\n|\n|\r)/gm, "")
+                .replace(tooltiptextRegex, "")
+                .replace(/<br>/gm, "\n")
+                .replace(htmlRegex, "");
+        }
+
         /*
         @name writeSheetHeader
         @description Writes sheet header and applies styling
@@ -695,7 +711,10 @@ searchModule.controller("searchController", [
             data.forEach((rowData, rowIndex) => {
                 rowIndex += 2;
                 sheet.row(rowIndex).height(24);
-                Object.entries(rowData).forEach(([_, value], cellIndex) => {
+                Object.entries(rowData).forEach(([type, value], cellIndex) => {
+                    if (["Numerator Formula (ind. only)", "Denominator Formula (ind. only)"].includes(type)) {
+                        if (value) value = stripHTML(value);
+                    }
                     const cell = sheet.cell(rowIndex, cellIndex + 1);
                     cell.value(value);
                     cell.style("wrapText", true);


### PR DESCRIPTION
## Fix loading status not displaying and incorrect calc. mode
### References

#### Issues:
- [Indicator section in selected Program - Takes too long to load](https://app.clickup.com/t/865ccwcyw)
- [Program Rules assigning values to one data element](https://app.clickup.com/t/865cqrehh)
- [Incorrect Calculation Mode for Data Elements](https://app.clickup.com/t/865cqrep0)

### Description
In the Indicator section case, the issue is two-fold:
- that table uses indicator descriptors and they are inherently slow
- each table marked loading as finished independently, when the dossier loads quickly its not noticeable, but when that's not the case the dossier is still loading but marked as loaded by "faster" tables.
Now the tables notify their loading status to a service to keep the loading status in sync.

For the calc. mode:
The issue was a ill-defined logic to determine the type of calc. mode of each dataElement. Some of the relevant code has been refactored.  