### PR TITLE
Fix URLs with double slash

### DIFF
--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -352,8 +352,7 @@ dossierProgramsModule.controller("makeIndicatorVisualizations", [
     "$scope",
     "$window",
     "dossiersProgramVisualizationTableFactory",
-    "dossiersProgramDataService",
-    function ($scope, $window, dossiersProgramVisualizationTableFactory, dossiersProgramDataService) {
+    function ($scope, $window, dossiersProgramVisualizationTableFactory) {
         $scope.getTable = function (name, id, rowItems) {
             const payload = {
                 name: "TEST",

--- a/app/dossierPrograms/dossierPrograms.services.js
+++ b/app/dossierPrograms/dossierPrograms.services.js
@@ -477,7 +477,7 @@ dossierProgramsModule.factory("dossiersProgramResourcesAttributeFactory", [
 ]);
 
 var qryProgramResourcesElements =
-    dhisUrl + "/metadata?filter=id\\:in\\:[:resourcesIDs]&fields=id,displayName,displayDescription";
+    dhisUrl + "metadata?filter=id\\:in\\:[:resourcesIDs]&fields=id,displayName,displayDescription";
 
 dossierProgramsModule.factory("dossiersProgramResourcesElementsFactory", [
     "$resource",

--- a/index.html
+++ b/index.html
@@ -100,8 +100,9 @@
                     window.dhis2 = window.dhis2 || {};
                     dhis2.settings = dhis2.settings || {};
 
-                    var dhisroot = window.location.href.replace(/#.*$/, "").split("api/")[0];
+                    var dhisroot = window.location.href.split("/api/")[0];
                     var dhisrootArr = dhisroot.split("/");
+                    dhisroot = window.location.href.replace(/\/#.*$/, "");
                     console.log("index.html: Prefix: " + dhisrootArr[3]);
                     if (dhisrootArr.length >= 4) {
                         dhis2.settings.baseUrl = dhisrootArr[3];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hmis-dictionary",
     "description": "DHIS2 HMIS Dictionary app",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "license": "GPL-3.0",
     "author": "MSF OCBA, EyeSeeTea team",
     "repository": {


### PR DESCRIPTION
## Fix URLs with double slash
### References

#### Issue:
- [[HMIS Dict] Review url path](https://app.clickup.com/t/865cynm4v)

### Description
Several URLs generated by the app had //, leading to errors.