### PR TITLE
Fix dhisroot having leftover URLs elements

### DIFF
--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -226,7 +226,7 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
                         if (adeArray.ids?.includes(pssDE.id) && isRuleInScope(adeArray, stage.id)) {
                             if (!pssDE.calcMode || pssDE.calcMode.type === "default") {
                                 pssDE.calcMode = { type: "programRule", names: [adeArray.name] };
-                            } else if (pssDE.calcMode.type === "programRule") {
+                            } else if (pssDE.calcMode?.type === "programRule") {
                                 pssDE.calcMode.names.push(adeArray.name);
                             }
                         } else if (!pssDE.calcMode) {
@@ -236,7 +236,7 @@ dossierProgramsModule.controller("dossiersProgramSectionController", [
 
                     hiddenSectionsArray.forEach(hsArray => {
                         if (hsArray.ids.includes(pss.id)) {
-                            if (pssDE.calcMode.type !== "programRule" && isRuleInScope(hsArray, stage.id)) {
+                            if (pssDE.calcMode?.type !== "programRule" && isRuleInScope(hsArray, stage.id)) {
                                 pssDE.calcMode = { type: "other" };
                             }
                         }
@@ -574,7 +574,7 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
          *  @scope dossiersProgramIndicatorController
          */
         function getStageNameById(id) {
-            return dossiersProgramDataService.data.stages.find(stage => stage.id === id)?.displayName;
+            return dossiersProgramDataService.data.stages?.find(stage => stage.id === id)?.displayName;
         }
 
         /*
@@ -662,16 +662,16 @@ dossierProgramsModule.controller("dossiersProgramIndicatorController", [
          *  @scope dossiersProgramIndicatorController
          */
         function getOptionNameById(stageId, deId, index) {
-            const stage = dossiersProgramDataService.data.stages.find(stage => stage.id === stageId);
+            const stage = dossiersProgramDataService.data.stages?.find(stage => stage.id === stageId);
 
-            const de = stage.programStageSections.flatMap(section => {
+            const de = stage?.programStageSections.flatMap(section => {
                 const de = section.dataElements.find(de => {
                     return de.id === deId;
                 });
                 return de ? de : [];
             })[0];
 
-            return de.optionSet?.options?.find(opt => opt.code === index)?.displayName;
+            return de?.optionSet?.options?.find(opt => opt.code === index)?.displayName;
         }
 
         /*

--- a/app/dossierPrograms/dossierPrograms.controllers.js
+++ b/app/dossierPrograms/dossierPrograms.controllers.js
@@ -521,7 +521,7 @@ dossierProgramsModule.controller("makeIndicatorVisualizations", [
 
                                     const uid = visualizationId;
 
-                                    $window.open(dhisroot + "/dhis-web-data-visualizer/index.html#/" + uid, "_blank");
+                                    $window.open(dhisroot + "dhis-web-data-visualizer/index.html#/" + uid, "_blank");
                                 }
                             );
                         }
@@ -534,7 +534,7 @@ dossierProgramsModule.controller("makeIndicatorVisualizations", [
                                 sharing,
                                 function (res) {}
                             );
-                            $window.open(dhisroot + "/dhis-web-data-visualizer/index.html#/" + uid, "_blank");
+                            $window.open(dhisroot + "dhis-web-data-visualizer/index.html#/" + uid, "_blank");
                         });
                     }
                 }

--- a/app/search/search.controllers.js
+++ b/app/search/search.controllers.js
@@ -352,7 +352,7 @@ searchModule.controller("searchController", [
                                     updateSharing.update({ uid: tbl.visualizations[0].id }, sharing, function (res) {});
 
                                     uid = tbl.visualizations[0].id;
-                                    $window.open(dhisroot + "/dhis-web-data-visualizer/index.html#/" + uid, "_blank");
+                                    $window.open(dhisroot + "dhis-web-data-visualizer/index.html#/" + uid, "_blank");
                                 }
                             );
                         }
@@ -363,7 +363,7 @@ searchModule.controller("searchController", [
                         searchTableFactory.set_table.query(payload, function (response) {
                             uid = response.response.uid;
                             updateSharing.update({ uid: uid }, sharing, function (res) {});
-                            $window.open(dhisroot + "/dhis-web-data-visualizer/index.html#/" + uid, "_blank");
+                            $window.open(dhisroot + "dhis-web-data-visualizer/index.html#/" + uid, "_blank");
                         });
                     }
                 }

--- a/index.html
+++ b/index.html
@@ -100,14 +100,16 @@
                     window.dhis2 = window.dhis2 || {};
                     dhis2.settings = dhis2.settings || {};
 
-                    var dhisroot = window.location.href.split("/api/")[0];
-                    var dhisrootArr = dhisroot.split("/");
-                    dhisroot = window.location.href.replace(/\/#.*$/, "").split("/api/")[0];
+                    var index_dhisroot = window.location.href.replace(/\/#.*$/, "").split("/api/")[0];
+                    var dhisrootArr = index_dhisroot.split("/");
+
                     console.log("index.html: Prefix: " + dhisrootArr[3]);
                     if (dhisrootArr.length >= 4) {
                         dhis2.settings.baseUrl = dhisrootArr[3];
                     } else {
-                        dhis2.settings.baseUrl = "";
+                        // NOTE: This hack is added to avoid the origin//api/i18n call made by dhis2.translate.js
+                        // dhis2.translate.js internal getBaseUrl function adds a / when the dhis base url its the same as the origin.
+                        dhis2.settings.baseUrl = ".";
                     }
                 </script>
 

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 
                     var dhisroot = window.location.href.split("/api/")[0];
                     var dhisrootArr = dhisroot.split("/");
-                    dhisroot = window.location.href.replace(/\/#.*$/, "");
+                    dhisroot = window.location.href.replace(/\/#.*$/, "").split("/api/")[0];
                     console.log("index.html: Prefix: " + dhisrootArr[3]);
                     if (dhisrootArr.length >= 4) {
                         dhis2.settings.baseUrl = dhisrootArr[3];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hmis-dictionary",
     "description": "DHIS2 HMIS Dictionary app",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "license": "GPL-3.0",
     "author": "MSF OCBA, EyeSeeTea team",
     "repository": {


### PR DESCRIPTION
## Fix URLs with double slash
### References

#### Issue:
- [Incorporate information about individual programs in WebApp HMIS Dictionary](https://app.clickup.com/t/36gckq1?comment=90040017964634)

### Description
Several URLs generated by the app had //, leading to errors. The previous fix worked only in the DEV environment. 
The `http://172.16.1.1:8093//api/i18n` calls seem to ignore the dhisroot variable.

On further investigation looks like the function `getBaseUrl` in `dhis-web-commons/javascripts/dhis2/dhis2.translate.js` gives an incorrect BaseUrl leading to the extra /.
![image](https://github.com/EyeSeeTea/HMIS-Dictionary/assets/34254522/a53604c0-355e-49a2-bef6-a0cc813fcf64)
![image](https://github.com/EyeSeeTea/HMIS-Dictionary/assets/34254522/147c25c4-f940-42f8-90bb-df6af098e19b)
