### PR TITLE
Set explicit text/plain POST type on expression

### DIFF
--- a/app/dossierPrograms/dossierPrograms.services.js
+++ b/app/dossierPrograms/dossierPrograms.services.js
@@ -152,6 +152,10 @@ dossierProgramsModule.factory("dossiersProgramIndicatorsFactory", [
     },
 ]);
 
+var expressionHeaders = {
+    "Content-Type": "text/plain",
+};
+
 var qryProgramIndicatorExpressions = dhisUrl + "programIndicators/expression/description";
 
 dossierProgramsModule.factory("dossiersProgramIndicatorExpressionFactory", [
@@ -165,6 +169,7 @@ dossierProgramsModule.factory("dossiersProgramIndicatorExpressionFactory", [
                     method: "POST",
                     data: "@expression",
                     isArray: false,
+                    headers: expressionHeaders,
                 },
             }
         );
@@ -184,6 +189,7 @@ dossierProgramsModule.factory("dossiersProgramIndicatorFilterFactory", [
                     method: "POST",
                     data: "@filter",
                     isArray: false,
+                    headers: expressionHeaders,
                 },
             }
         );


### PR DESCRIPTION
Closes https://app.clickup.com/t/86963g9fk

![image](https://github.com/user-attachments/assets/8d69efa3-3add-4463-9870-db806a15f5c6)

The default content-type in Angular is JSON, while the expression is a plain text. Set explicit header, as it seems 2.40 is checking its value.