### PR TITLE
Fix: Dictionary gets frozen after opening one visualization from the Search section

### DIFF
--- a/app/search/search.controllers.js
+++ b/app/search/search.controllers.js
@@ -449,7 +449,7 @@ searchModule.controller("searchController", [
             payload.name = name + " - " + id;
             payload.rows[0].items = items;
 
-            $scope.table = getTableFactory.query(
+            getTableFactory.query(
                 {
                     filter: "name:eq:" + payload.name,
                 },

--- a/app/search/search.view.html
+++ b/app/search/search.view.html
@@ -239,9 +239,11 @@
                 data-title="'object_name' | translate" data-header-title="'object_name_help' | translate">
                 <span
                     ng-bind-html='object.object_name | highlight: table.globalSearchTerm:params.filter():"object_name"'></span>
-                <a ng-if="object.object_type == 'indicator'" href="" ng-click="getTable(object.object_name,
-			object.object_id,object.object_numerator ,  object.object_denominator)"><img src="./assets/img/pivottable.png"
-                        alt="View Table" width="15" /></a>
+                <button
+                    ng-if="object.object_type == 'indicator'" type="button" class="btn btn-link btn-xs"
+                    ng-click="getTable(object.object_name, object.object_id, object.object_numerator, object.object_denominator)">
+                    <img src="./assets/img/pivottable.png" alt="View Table" width="15" />
+                </button>
             </td>
             <td sortable="'object_form'" filter="{object_form:'./app/search/search.table.html'}" ng-if="false"
                 data-title="'object_form' | translate" data-header-title="'object_form_help' | translate">


### PR DESCRIPTION
### Task:
- [[57] Dictionary gets frozen after opening one visualization from the Search section](https://app.clickup.com/t/869bxq0am)

### Description:
Search page gets partially frozen (search bar, column manager, help) after opening an Indicator visualization.

### Screenshots/Screen capture
![Peek 2026-01-27 21-43](https://github.com/user-attachments/assets/fbc2023e-e4c3-4cc3-a1a0-b107a5a25808)
