### PR TITLE
[Fix] Remove double header for v42

### DIFF
--- a/app/app.css.css
+++ b/app/app.css.css
@@ -19,15 +19,18 @@ h6 {
     font-family: "Rajdhani", sans-serif;
 }
 
-.nav > li > a {
+.nav>li>a {
     color: #ddd;
 }
+
 .active {
     color: black;
 }
+
 a:visited {
     color: #bbb;
 }
+
 a {
     text-decoration: underline;
     color: #696969;
@@ -65,26 +68,60 @@ a {
 /* Print                                                                      */
 /*----------------------------------------------------------------------------*/
 
-#print-foot {
+html.in-global-shell #print-btn-fixed {
+    display: block;
+}
+
+html.in-global-shell .printButtonHeader {
     display: none;
 }
 
-.printButton {
+html:not(.in-global-shell) #print-btn-fixed {
+    display: none;
+}
+
+.printButtonHeader {
     margin: 3px 0 0 -40px;
     color: white;
     border-style: none;
 }
-.printButton:hover,
-.printButton:focus,
-.printButton:active {
+
+.printButtonHeader:hover,
+.printButtonHeader:focus,
+.printButtonHeader:active {
     color: white;
     background-color: #ddd;
 }
 
+#print-btn-fixed {
+    display: none;
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    color: #555;
+    z-index: 100;
+}
+
+#print-foot {
+    display: none;
+}
+
 @media print {
-    #header, #menu-container, #menu-background, #headerDossierPanel /*dossiers.view*/, #editDescButton /*dossiersReader.view*/, #backtotop {
-        display: none;
+    #header,
+    #menu-container,
+    #menu-background,
+    #headerDossierPanel
+    /*dossiers.view*/
+    ,
+    #editDescButton
+
+    /*dossiersReader.view*/
+    ,
+    #backtotop,
+    #print-btn-fixed {
+        display: none !important;
     }
+
     a[href]:after {
         content: none !important;
     }
@@ -105,14 +142,16 @@ a {
         page-break-before: always;
     }
 
-    .service > .dataset:first-child,
+    .service>.dataset:first-child,
     .indicatorGroup:first-child {
         page-break-before: avoid;
     }
-    .service > .dataset,
+
+    .service>.dataset,
     .indicatorGroup {
         page-break-before: always;
     }
+
     /* works only properly in firefox */
     @-moz-document url-prefix() {
         #print-foot:after {
@@ -120,6 +159,7 @@ a {
             counter-increment: page;
         }
     }
+
     @page {
         /*size: auto;   /* auto is the initial value */
 
@@ -131,6 +171,14 @@ a {
 /*----------------------------------------------------------------------------*/
 /* Header                                                                     */
 /*----------------------------------------------------------------------------*/
+
+html.in-global-shell #header {
+    display: none;
+}
+
+html.in-global-shell #view-container {
+    margin-top: 0;
+}
 
 #header {
     background-color: #b40303;

--- a/app/dossiersEditor/dossiersEditor.controllers.js
+++ b/app/dossiersEditor/dossiersEditor.controllers.js
@@ -10,15 +10,13 @@ dossiersEditorModule.controller("dossiersEditorMainController", [
     "dossiersDossierFactory",
     "dossiersEditorTranslationsFactory",
     "dossiersEditorUpdateDescriptionFactory",
-    "dossiersEditorCreateDescriptionFactory",
     function (
         $scope,
         dossiersReaderMeFactory,
         dossiersServicesFactory,
         dossiersDossierFactory,
         dossiersEditorTranslationsFactory,
-        dossiersEditorUpdateDescriptionFactory,
-        dossiersEditorCreateDescriptionFactory
+        dossiersEditorUpdateDescriptionFactory
     ) {
         startLoadingState();
 

--- a/app/dossiersEditor/dossiersEditor.services.js
+++ b/app/dossiersEditor/dossiersEditor.services.js
@@ -41,20 +41,3 @@ dossiersEditorModule.factory("dossiersEditorUpdateDescriptionFactory", [
         );
     },
 ]);
-
-var qryCreateDescription = dhisUrl + "translations/";
-
-dossiersEditorModule.factory("dossiersEditorCreateDescriptionFactory", [
-    "$resource",
-    function ($resource) {
-        return $resource(
-            qryCreateDescription,
-            {},
-            {
-                create: {
-                    method: "POST",
-                },
-            }
-        );
-    },
-]);

--- a/index.html
+++ b/index.html
@@ -4,6 +4,18 @@
 <head>
     <title>Metadata Dictionary</title>
 
+    <script>
+        (function () {
+            var inGlobalShell = window.self !== window.top;
+            window.HMIS_IN_GLOBAL_SHELL = inGlobalShell;
+
+            if (inGlobalShell) {
+                document.documentElement.className +=
+                    (document.documentElement.className ? " " : "") + "in-global-shell";
+            }
+        })();
+    </script>
+
     <!-- dependencies: jQuery -->
     <script src="bower_components/jquery/jquery.min.js"></script>
 
@@ -144,7 +156,7 @@
                 <div class="col-xs-11" d2-menu></div>
                 <div class="col-xs-1 pull-right">
                     <button disabled="disabled" type="button" onclick="javascript:window.print()"
-                        class="btn btn-link btn-lg printButton">
+                        class="btn btn-link btn-lg printButton printButtonHeader">
                         <span aria-hidden="true" class="glyphicon glyphicon-print"></span>
                     </button>
                 </div>
@@ -174,6 +186,32 @@
             <!--<li id="graph" role="presentation"><a href="#graph" data-toggle="tab">{{'idx_Graph' | translate}}</a></li> -->
         </ul>
         <div id="menu-background"></div>
+
+        <div id="print-btn-fixed-slot"></div>
+        <script>
+            if (window.HMIS_IN_GLOBAL_SHELL) {
+                var slot = document.getElementById("print-btn-fixed-slot");
+                var wrapper = document.createElement("div");
+                var button = document.createElement("button");
+                var icon = document.createElement("span");
+
+                wrapper.id = "print-btn-fixed";
+
+                button.disabled = true;
+                button.type = "button";
+                button.className = "btn btn-default btn-lg printButton printButtonFloating";
+                button.onclick = function () {
+                    window.print();
+                };
+
+                icon.setAttribute("aria-hidden", "true");
+                icon.className = "glyphicon glyphicon-print";
+
+                button.appendChild(icon);
+                wrapper.appendChild(button);
+                slot.appendChild(wrapper);
+            }
+        </script>
 
         <!-- app: view-container -->
         <div id="view-container">


### PR DESCRIPTION
Update app to function with DHIS 2.42 global shell as well as older versions.

In v42 the header is the global header. The print button is moved to a standalone button.
<img width="1531" height="860" alt="image" src="https://github.com/user-attachments/assets/a77575ce-7ddf-49c6-a2ba-c4820d5315f9" />

In older versions the app is unchanged:
<img width="1536" height="860" alt="image" src="https://github.com/user-attachments/assets/b870eba6-a158-4970-bfbf-afb82981fc8d" />
