### PR TITLE
[Fix] Dossier editor not showing the correct translation with DHIS2.42

### DIFF
--- a/app/dossiers/dossiers.services.js
+++ b/app/dossiers/dossiers.services.js
@@ -43,7 +43,8 @@ dossiersModule.factory("dossiersServiceDataSetsFactory", [
 ]);
 
 var qryDossier =
-    dhisUrl + "organisationUnitGroups/:serviceId.json?fields=displayDescription&paging=false&locale=:languageCode";
+    dhisUrl +
+    "organisationUnitGroups/:serviceId.json?fields=displayDescription&paging=false&translate=true&locale=:languageCode";
 
 dossiersModule.factory("dossiersDossierFactory", [
     "$resource",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hmis-dictionary",
     "description": "DHIS2 HMIS Dictionary app",
-    "version": "1.14.0",
+    "version": "1.14.1",
     "license": "GPL-3.0",
     "author": "MSF OCBA, EyeSeeTea team",
     "repository": {


### PR DESCRIPTION
### Task:
- [DHIS2 42: HMIS Dictionary](https://app.clickup.com/t/869cc8gmj)

### Description:
Reported issue: 
When trying to edit the dossier it is not shown in the language selected.

Cause: 
The API call `api/organisationUnitGroups/<ID>.json?fields=displayDescription&paging=false&locale=<LOCALE>` ignores the `locale` param in DHIS2.42 unless the `translate=true` param is added. The documentation states that `translate` has true as default value, and hence why it worked in previous versions. 

DHIS2.42 either suffered a regression or its an undocumented change.

### Screenshots/Screen capture
![Peek 2026-04-09 12-52](https://github.com/user-attachments/assets/6c631340-ca41-4ef0-8f7e-0441b394d961)
