### PR TITLE
[Fix] Issues saving layout settings

### DIFF
--- a/app/layoutSettings/layoutSettings.controller.js
+++ b/app/layoutSettings/layoutSettings.controller.js
@@ -31,7 +31,7 @@ layoutSettingsModule.controller("SharingSettingsController", [
             }
         }
 
-        const previousAdvancedUsers = JSON.stringify($scope.state.advancedUserGroups);
+        var previousAdvancedUsers = JSON.stringify($scope.state.advancedUserGroups);
         $scope.advancedUsers = previousAdvancedUsers;
 
         $scope.restore = () => {
@@ -45,6 +45,15 @@ layoutSettingsModule.controller("SharingSettingsController", [
         $scope.previousRows = angular.copy($scope.rows);
         $scope.hasChanges = () =>
             !angular.equals($scope.rows, $scope.previousRows) || $scope.advancedUsers !== previousAdvancedUsers;
+
+        var unregisterStateWatch = $scope.$watch("state", function (newState, oldState) {
+            if (newState === oldState || !newState) return;
+            previousAdvancedUsers = JSON.stringify(newState.advancedUserGroups);
+            $scope.restore();
+            $scope.previousRows = angular.copy($scope.rows);
+        });
+
+        $scope.$on("$destroy", unregisterStateWatch);
 
         $scope.showInvalidFormat = false;
         $scope.showInvalidUserGroup = false;


### PR DESCRIPTION
## Task

- [Issue saving settings in Search](https://app.clickup.com/t/869d1mbku)

## Description

Issue was hard to debug, as it rarely happened in local or  test instances.

Using mitmproxy helped to make the issue consistent by adding a delay to the dataStore GET call. The issue was that the scope would initialize with the default `layoutSettings` instead of the dataStore ones.

#869d1mbku