### PR TITLE
[Fix] Show blacklisted DataElements in search Indicators formulas 

### DIFF
--- a/app/admin/admin.view.html
+++ b/app/admin/admin.view.html
@@ -9,7 +9,7 @@
 
         <div class="col-md-12">
             <div class="alert alert-info rounded" role="alert">
-                This version of the app has been tested for dhis v2.37.10 with default locale assumed to be <u>English</u> and accepts tranlsations in <u>Spanish</u>, <u>French</u> and <u>Portuguese</u>. The latest version is available at: <a href=https://github.com/EyeSeeTea/HMIS-Dictionary><font color="blue">https://github.com/EyeSeeTea/HMIS-Dictionary</font></a>.
+                This version of the app has been tested for dhis v2.42.4 with default locale assumed to be <u>English</u> and accepts tranlsations in <u>Spanish</u>, <u>French</u>, <u>Portuguese</u> and <u>Arabic</u>. The latest version is available at: <a href=https://github.com/EyeSeeTea/HMIS-Dictionary><font color="blue">https://github.com/EyeSeeTea/HMIS-Dictionary</font></a>.
             </div>
         </div>
 

--- a/app/app.css.css
+++ b/app/app.css.css
@@ -213,6 +213,18 @@ html.in-global-shell #view-container {
     margin-top: 0;
 }
 
+html.in-global-shell .loading {
+    background-color: #ffffff00;
+}
+
+html.in-global-shell .loading .spinner {
+    filter: invert(0);
+}
+
+html.in-global-shell .loading .loading-message {
+    color: #000000;
+}
+
 #header {
     background-color: #b40303;
     height: 44px;

--- a/app/search/search.controllers.js
+++ b/app/search/search.controllers.js
@@ -827,6 +827,7 @@ searchModule.controller("searchController", [
             var start = new Date();
 
             var temp = {};
+            var allDataElementsTemp = {};
             var categoryOptionCombosTemp = {};
             var programIndicatorsTemp = {};
             var indicatorsTemp = {};
@@ -909,6 +910,15 @@ searchModule.controller("searchController", [
                                 service_name: _.uniq(temp_arr.service_name).join(", "),
                             };
                         });
+
+                    response.dataElements.forEach(function (obj) {
+                        allDataElementsTemp[obj.id] = {
+                            id: obj.id,
+                            object_name: obj.displayName,
+                            object_form: obj.displayFormName,
+                            object_description: obj.displayDescription,
+                        };
+                    });
 
                     $scope.loaded.get_dataElements = true;
                     $scope.loaded.get_dataElementsDescriptions = true;
@@ -1024,7 +1034,7 @@ searchModule.controller("searchController", [
                                 object_denominator: obj.denominator,
                                 object_den_formula: $scope.parseFormula(
                                     obj.denominator,
-                                    temp,
+                                    allDataElementsTemp,
                                     categoryOptionCombosTemp,
                                     programIndicatorsTemp,
                                     indicatorsTemp,
@@ -1032,7 +1042,7 @@ searchModule.controller("searchController", [
                                 ),
                                 object_num_formula: $scope.parseFormula(
                                     obj.numerator,
-                                    temp,
+                                    allDataElementsTemp,
                                     categoryOptionCombosTemp,
                                     programIndicatorsTemp,
                                     indicatorsTemp,
@@ -1070,7 +1080,7 @@ searchModule.controller("searchController", [
                             object_filter: obj.object_filter,
                             object_exp_formula: $scope.parseFormula(
                                 obj.object_expression,
-                                temp,
+                                allDataElementsTemp,
                                 categoryOptionCombosTemp,
                                 programIndicatorsTemp,
                                 indicatorsTemp,
@@ -1078,7 +1088,7 @@ searchModule.controller("searchController", [
                             ),
                             object_flt_formula: $scope.parseFormula(
                                 obj.object_filter,
-                                temp,
+                                allDataElementsTemp,
                                 categoryOptionCombosTemp,
                                 programIndicatorsTemp,
                                 indicatorsTemp,
@@ -1095,7 +1105,7 @@ searchModule.controller("searchController", [
                     $scope.loaded.get_programIndicatorGroups = true;
 
                     $scope.formulaSources = {
-                        dataElements: temp,
+                        dataElements: allDataElementsTemp,
                         categoryOptionCombos: categoryOptionCombosTemp,
                         programIndicators: programIndicatorsTemp,
                         indicators: indicatorsTemp,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hmis-dictionary",
     "description": "DHIS2 HMIS Dictionary app",
-    "version": "1.15.0",
+    "version": "1.15.1",
     "license": "GPL-3.0",
     "author": "MSF OCBA, EyeSeeTea team",
     "repository": {


### PR DESCRIPTION
## Task

- [No specific task for the fix, link to parent task](https://app.clickup.com/t/4528615/869bvmxuk)

## Description

- Search page: For indicators, the formula parsing excluded blacklisted dataElements, showing their ID. Fixed the page logic to pass all the dataElements to the formula parsing.

Misc fixes:
- Admin page: Updated mentioned DHIS2 version and added Arabic to language list.
- All pages: Fixed the loading spinner using a red background when using with global shell. Non global shell spinner is unchanged.

## Screenshots
Original:
<img width="1488" height="641" alt="image" src="https://github.com/user-attachments/assets/e0c4b154-4019-4955-a201-c92dbd454aed" />

Formulas fix:
<img width="1397" height="678" alt="image" src="https://github.com/user-attachments/assets/5267db48-7d5e-43a9-a673-eeca901682bd" />

Admin new description:
<img width="1368" height="150" alt="image" src="https://github.com/user-attachments/assets/0345f0c4-f59d-4a8b-a4c1-7bd9eb24a60a" />

Broken spinner:
<img width="1321" height="345" alt="image" src="https://github.com/user-attachments/assets/a54a9c74-224a-47a2-a8f1-8e33eec24959" />

Fixed loading spinner:
<img width="1394" height="332" alt="image" src="https://github.com/user-attachments/assets/501de801-9483-4fac-aee1-c64ca37542e5" />
